### PR TITLE
fix: support odd axes number

### DIFF
--- a/src/GamepadHandler.js
+++ b/src/GamepadHandler.js
@@ -13,7 +13,7 @@ export default class GamepadHandler extends EventEmitter {
 
         this.index = index;
         this.options = this.constructor.resolveOptions(options);
-        this.sticks = new Array(gamepad.axes.length / 2).fill(null).map(() => [null, null]);
+        this.sticks = new Array(Math.ceil(gamepad.axes.length / 2)).fill(null).map(() => [null, null]);
         this.buttons = new Array(gamepad.buttons.length).fill(null);
 
         this.updateStick = this.updateStick.bind(this);


### PR DESCRIPTION
This makes the code work in case `gamepad.axes.length` is `1` or any other odd number. It will round it up to the closest integer as expected.